### PR TITLE
More fixes for Arcade 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ FIRECRAWL_API_KEY=
 ARCADE_API_KEY=
 ```
 
+If you plan to post to LinkedIn as an organization (rather than as yourself), you'll also need to set:
+
+```bash
+# Get the organization ID from the URL of the company page when you're logged in as an admin.
+# For example, if the URL is `https://www.linkedin.com/company/12345678/admin/dashboard/`, the organization ID would be `12345678`.
+POST_TO_LINKEDIN_ORGANIZATION=true
+LINKEDIN_ORGANIZATION_ID=
+```
+
 ### Install LangGraph CLI
 
 ```bash
@@ -216,6 +225,15 @@ Regardless of the method you choose, you will need to set these environment vari
 Create an Arcade account [here](https://www.arcade.dev). After you register, [get an Arcade API key](https://docs.arcade.dev/home/quickstart?lang=typescript). Set this value as `ARCADE_API_KEY` in your `.env` file.
 
 Make sure you have the `USE_ARCADE_AUTH` environment variable set to `true` to have the graph use Arcade authentication.
+
+If you plan to post to LinkedIn as an organization (rather than as yourself), you'll also need to set:
+
+```bash
+# Get the organization ID from the URL of the company page when you're logged in as an admin.
+# For example, if the URL is `https://www.linkedin.com/company/12345678/admin/dashboard/`, the organization ID would be `12345678`.
+LINKEDIN_ORGANIZATION_ID=
+POST_TO_LINKEDIN_ORGANIZATION=true
+```
 
 > Note:
 >

--- a/src/agents/shared/auth/linkedin.ts
+++ b/src/agents/shared/auth/linkedin.ts
@@ -100,13 +100,9 @@ async function getArcadeLinkedInAuthOrInterrupt(
   const scopes = fields?.postToOrg
     ? ["w_member_social", "w_organization_social"]
     : ["w_member_social"];
-  const authResponse = await arcade.auth.start(
-    linkedInUserId,
-    "linkedin",
-    {
-      scopes,
-    }
-  )
+  const authResponse = await arcade.auth.start(linkedInUserId, "linkedin", {
+    scopes,
+  });
   const authUrl = authResponse.url;
 
   if (authUrl) {

--- a/src/agents/shared/auth/linkedin.ts
+++ b/src/agents/shared/auth/linkedin.ts
@@ -100,15 +100,13 @@ async function getArcadeLinkedInAuthOrInterrupt(
   const scopes = fields?.postToOrg
     ? ["w_member_social", "w_organization_social"]
     : ["w_member_social"];
-  const authResponse = await arcade.auth.authorize({
-    user_id: linkedInUserId,
-    auth_requirement: {
-      provider_id: "linkedin",
-      oauth2: {
-        scopes,
-      },
-    },
-  });
+  const authResponse = await arcade.auth.start(
+    linkedInUserId,
+    "linkedin",
+    {
+      scopes,
+    }
+  )
   const authUrl = authResponse.url;
 
   if (authUrl) {

--- a/src/clients/linkedin.ts
+++ b/src/clients/linkedin.ts
@@ -286,13 +286,9 @@ export class LinkedInClient {
     },
   ): Promise<AuthorizeUserResponse> {
     const scopes = LinkedInClient.getScopes(fields?.postToOrganization);
-    const authRes = await client.auth.start(
-      id,
-      "linkedin",
-      {
-        scopes,
-      }
-    )
+    const authRes = await client.auth.start(id, "linkedin", {
+      scopes,
+    });
 
     if (authRes.status === "completed") {
       if (!authRes.context?.token) {
@@ -322,13 +318,9 @@ export class LinkedInClient {
       apiKey: process.env.ARCADE_API_KEY,
     });
     const scopes = LinkedInClient.getScopes(fields?.postToOrganization);
-    const authRes = await arcade.auth.start(
-      linkedInUserId,
-      "linkedin",
-      {
-        scopes,
-      }
-    )
+    const authRes = await arcade.auth.start(linkedInUserId, "linkedin", {
+      scopes,
+    });
 
     if (!authRes.context?.token || !authRes.context?.user_info?.sub) {
       throw new Error(

--- a/src/clients/linkedin.ts
+++ b/src/clients/linkedin.ts
@@ -286,15 +286,13 @@ export class LinkedInClient {
     },
   ): Promise<AuthorizeUserResponse> {
     const scopes = LinkedInClient.getScopes(fields?.postToOrganization);
-    const authRes = await client.auth.authorize({
-      user_id: id,
-      auth_requirement: {
-        provider_id: "linkedin",
-        oauth2: {
-          scopes,
-        },
-      },
-    });
+    const authRes = await client.auth.start(
+      id,
+      "linkedin",
+      {
+        scopes,
+      }
+    )
 
     if (authRes.status === "completed") {
       if (!authRes.context?.token) {
@@ -324,15 +322,13 @@ export class LinkedInClient {
       apiKey: process.env.ARCADE_API_KEY,
     });
     const scopes = LinkedInClient.getScopes(fields?.postToOrganization);
-    const authRes = await arcade.auth.authorize({
-      user_id: linkedInUserId,
-      auth_requirement: {
-        provider_id: "linkedin",
-        oauth2: {
-          scopes,
-        },
-      },
-    });
+    const authRes = await arcade.auth.start(
+      linkedInUserId,
+      "linkedin",
+      {
+        scopes,
+      }
+    )
 
     if (!authRes.context?.token || !authRes.context?.user_info?.sub) {
       throw new Error(

--- a/src/clients/twitter/client.ts
+++ b/src/clients/twitter/client.ts
@@ -110,13 +110,9 @@ export class TwitterClient {
     id: string,
     client: Arcade,
   ): Promise<AuthorizeUserResponse> {
-    const authRes = await client.auth.start(
-      id,
-      "x",
-      {
-        scopes: ["tweet.write", "users.read", "tweet.read", "offline.access"],
-      }
-    );
+    const authRes = await client.auth.start(id, "x", {
+      scopes: ["tweet.write", "users.read", "tweet.read", "offline.access"],
+    });
 
     if (authRes.status === "completed") {
       if (!authRes.context?.token) {

--- a/src/clients/twitter/client.ts
+++ b/src/clients/twitter/client.ts
@@ -110,15 +110,13 @@ export class TwitterClient {
     id: string,
     client: Arcade,
   ): Promise<AuthorizeUserResponse> {
-    const authRes = await client.auth.authorize({
-      user_id: id,
-      auth_requirement: {
-        provider_id: "x",
-        oauth2: {
-          scopes: ["tweet.write", "users.read", "tweet.read", "offline.access"],
-        },
-      },
-    });
+    const authRes = await client.auth.start(
+      id,
+      "x",
+      {
+        scopes: ["tweet.write", "users.read", "tweet.read", "offline.access"],
+      }
+    );
 
     if (authRes.status === "completed") {
       if (!authRes.context?.token) {


### PR DESCRIPTION
In this PR:
- Switch to the simpler `auth.start()` method available in arcadejs 1.0.0 (I missed this in #93)
- Clarify in the README the env vars that need to be set in order to post as a LinkedIn organization, regardless of the auth method.