### PR TITLE
fix #156 cannot use namespace 'Arcade' as a type

### DIFF
--- a/src/agents/shared/auth/linkedin.ts
+++ b/src/agents/shared/auth/linkedin.ts
@@ -92,7 +92,7 @@ If you have already authorized and set the required configuration fields or envi
 
 async function getArcadeLinkedInAuthOrInterrupt(
   linkedInUserId: string,
-  arcade: Arcade,
+  arcade: InstanceType<typeof Arcade>,
   fields?: {
     returnInterrupt?: boolean;
     postToOrg?: boolean;

--- a/src/agents/shared/auth/twitter.ts
+++ b/src/agents/shared/auth/twitter.ts
@@ -23,7 +23,7 @@ import { useArcadeAuth } from "../../utils.js";
  */
 export async function getArcadeTwitterAuthOrInterrupt(
   twitterUserId: string,
-  arcade: Arcade,
+  arcade: InstanceType<typeof Arcade>,
   options?: {
     returnInterrupt?: boolean;
   },

--- a/src/clients/linkedin.ts
+++ b/src/clients/linkedin.ts
@@ -280,7 +280,7 @@ export class LinkedInClient {
    */
   static async authorizeUser(
     id: string,
-    client: Arcade,
+    client: InstanceType<typeof Arcade>,
     fields?: {
       postToOrganization?: boolean;
     },

--- a/src/clients/twitter/client.ts
+++ b/src/clients/twitter/client.ts
@@ -114,7 +114,7 @@ export class TwitterClient {
    */
   static async authorizeUser(
     id: string,
-    client: Arcade,
+    client: InstanceType<typeof Arcade>,
   ): Promise<AuthorizeUserResponse> {
     const authRes = await client.auth.start(id, "x", {
       scopes: ["tweet.write", "users.read", "tweet.read", "offline.access"],


### PR DESCRIPTION
The issue that I'm trying to solve here is described in #156. Here I replace declarations of **Arcade**:

```typescript
  arcade: Arcade,
```

with declarations like this one:

```typescript
  arcade: InstanceType<typeof Arcade>,
```

The issue seems to be solved and all tests are passing.