### PR TITLE
fix #158 build the docker image fails at installing playwright

### DIFF
--- a/langgraph.json
+++ b/langgraph.json
@@ -18,5 +18,5 @@
   },
   "env": ".env",
   "dependencies": ["."],
-  "dockerfile_lines": ["RUN npx -y playwright@1.49.1 install --with-deps"]
+  "dockerfile_lines": ["RUN yarn add -D playwright@1.49.1 && npx playwright install --with-deps"]
 }


### PR DESCRIPTION
The issue that motivates this PR is #158 and it includes a log trace and version details of what this solves.