### PR TITLE
build: restore LangGraph Platform checkpoint compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
         versions: [">=2.110.0"]
       - dependency-name: "file-type"
         versions: [">=22.0.0"]
+      - dependency-name: "@langchain/langgraph"
+        versions: [">=1.4.0"]
     groups:
       minor-and-patch:
         patterns:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@langchain/community": "^1.1.29",
     "@langchain/core": "^1.2.3",
     "@langchain/google-vertexai-web": "^2.2.0",
-    "@langchain/langgraph": "^1.4.8",
+    "@langchain/langgraph": "1.3.7",
     "@langchain/langgraph-sdk": "1.9.28",
     "@langchain/openai": "^1.5.5",
     "@mendable/firecrawl-js": "1.10.1",
@@ -71,6 +71,7 @@
     "zod": "^4.4.3"
   },
   "resolutions": {
+    "@langchain/langgraph-checkpoint": "1.0.4",
     "axios": "^1.18.1",
     "jws": "^4.0.1",
     "form-data": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,12 +1243,14 @@
     "@langchain/google-common" "2.2.0"
     web-auth-library "^1.0.3"
 
-"@langchain/langgraph-checkpoint@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz#891f2f9a2e96cf2ab0920f9240f9ad1e0a86a4ab"
-  integrity sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==
+"@langchain/langgraph-checkpoint@1.0.4", "@langchain/langgraph-checkpoint@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.4.tgz#893aa7255b2fe810fdeb50281f6750a3b0a6fef7"
+  integrity sha512-1y5MgZ0gXXrtmoy56e3kaBChI3GwFPIKl27xkrHwN+VE/3iUsyr9gO3Jtp7kdKAe6diZGbcas5bdC/r0yUwTZA==
+  dependencies:
+    uuid "^14.0.0"
 
-"@langchain/langgraph-sdk@1.9.28", "@langchain/langgraph-sdk@~1.9.26":
+"@langchain/langgraph-sdk@1.9.28", "@langchain/langgraph-sdk@~1.9.19":
   version "1.9.28"
   resolved "https://registry.yarnpkg.com/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz#1664cc7b6f2c1509ddffecf17d805a26e70a7e1a"
   integrity sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==
@@ -1258,15 +1260,16 @@
     p-queue "^9.0.1"
     p-retry "^7.1.1"
 
-"@langchain/langgraph@^1.4.8":
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph/-/langgraph-1.4.8.tgz#65ef5635b5554cd32f502a3808b92d8371998a99"
-  integrity sha512-DN1Np1XefdBEbp1qBKlt39cwoL743AAGpR5Ipja0gY2YbWvsoQnOTIrjnj/orSAhaUYsdTKS8VSWdFzsHZo6Ig==
+"@langchain/langgraph@1.3.7":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@langchain/langgraph/-/langgraph-1.3.7.tgz#2f7430a42875689e98947a4060e6a2de461a2eb4"
+  integrity sha512-6WNskiu3bpy3XFwiD9cm4n2QapnFVX7dqYeJzuEAUGp9R3vbxngRVyb5+Myp5Rz4GCFXGXuhcFSjLVRHPhsNtQ==
   dependencies:
-    "@langchain/langgraph-checkpoint" "^1.1.3"
-    "@langchain/langgraph-sdk" "~1.9.26"
-    "@langchain/protocol" "^0.0.18"
+    "@langchain/langgraph-checkpoint" "^1.0.4"
+    "@langchain/langgraph-sdk" "~1.9.19"
+    "@langchain/protocol" "^0.0.16"
     "@standard-schema/spec" "1.1.0"
+    uuid "^14.0.0"
 
 "@langchain/openai@1.4.5":
   version "1.4.5"
@@ -1285,6 +1288,11 @@
     js-tiktoken "^1.0.12"
     openai "^6.41.0"
     zod "^3.25.76 || ^4"
+
+"@langchain/protocol@^0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@langchain/protocol/-/protocol-0.0.16.tgz#68b63d58feaf4f0acf77405cb8fb16f9c3f09b60"
+  integrity sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==
 
 "@langchain/protocol@^0.0.18":
   version "0.0.18"


### PR DESCRIPTION
## What
Pins the LangGraph packages to the newest pair supported by the hosted Platform image and prevents Dependabot from restoring the incompatible line.

## Why
The hosted API image rejects checkpoint 1.1.3 during its prebuild check because it currently accepts the 1.0.x line. LangGraph 1.4.8 requires checkpoint 1.1.3.

## How
- Pin LangGraph to 1.3.7.
- Resolve checkpoint exactly to 1.0.4, within the declared dependency range.
- Ignore LangGraph 1.4+ Dependabot updates until the Platform image supports checkpoint 1.1.x.

## Testing
- [x] `sfw yarn install --frozen-lockfile`
- [x] Asserted LangGraph 1.3.7 and checkpoint 1.0.4 from installed package metadata
- [x] `yarn build`