### PR TITLE
fix: reuse supervisor reports channel

### DIFF
--- a/src/agents/supervisor/supervisor-state.ts
+++ b/src/agents/supervisor/supervisor-state.ts
@@ -1,6 +1,7 @@
 import { Annotation } from "@langchain/langgraph";
 import { Source } from "./types.js";
 import { CuratedData } from "../curate-data/types.js";
+import { GenerateReportAnnotation } from "../generate-report/state.js";
 
 export const SupervisorAnnotation = Annotation.Root({
   /**
@@ -11,15 +12,7 @@ export const SupervisorAnnotation = Annotation.Root({
    * A list of reports, each containing a report & key details on a given data source/data group.
    * The report is used for generating a post, and key details are used for identifying reports on the same topic.
    */
-  reports: Annotation<
-    Array<{
-      report: string;
-      keyDetails: string;
-    }>
-  >({
-    reducer: (state, update) => state.concat(update),
-    default: () => [],
-  }),
+  reports: GenerateReportAnnotation.spec.reports,
   /**
    * The list of reports after they have been grouped.
    */


### PR DESCRIPTION
## Summary

- Reuse the generate-report graph's existing `reports` channel in the supervisor state.
- Prevent LangGraph from registering two incompatible channels during graph import, which caused new deployments to fail during startup.

## Test Plan

- [x] Imported `supervisor-graph.ts` with the current dependencies and confirmed graph initialization succeeds without the duplicate-channel error.
