### PR TITLE
feat(llm): add OrcaRouter gateway for chat models

### DIFF
--- a/.env.full.example
+++ b/.env.full.example
@@ -59,6 +59,13 @@ USE_TWITTER_API_ONLY=false
 
 # LLM API Keys
 ANTHROPIC_API_KEY=
+# Optional: route all chat model calls through the OrcaRouter gateway
+# (https://api.orcarouter.ai/v1) instead of the default provider endpoints.
+# Requires an API key from https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
+# Optional overrides (only used when ORCAROUTER_API_KEY is set)
+ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+ORCAROUTER_MODEL=orcarouter/auto
 # Optional, only set if not running in basic setup mode
 GOOGLE_VERTEX_AI_WEB_CREDENTIALS=
 

--- a/.env.quickstart.example
+++ b/.env.quickstart.example
@@ -5,6 +5,11 @@ LANGCHAIN_TRACING_V2=true
 # For LLM generations
 ANTHROPIC_API_KEY=
 
+# Optional: route all chat model calls through the OrcaRouter gateway
+# (https://api.orcarouter.ai/v1) instead of the default provider endpoints.
+# Requires an API key from https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
+
 # For web scraping
 FIRECRAWL_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ To get started, you'll need the following API keys/software:
 - [FireCrawl API](https://www.firecrawl.dev/) - Web scraping. New users get 500 credits for free
 - [Arcade](https://www.arcade.dev/) - Easy authentication for reading & writing to social media platforms
 
+> **Optional: use [OrcaRouter](https://www.orcarouter.ai) as the model gateway.**
+> Instead of calling Anthropic/OpenAI directly, set `ORCAROUTER_API_KEY` and all chat
+> model calls in this repo are routed through the OrcaRouter gateway
+> (`https://api.orcarouter.ai/v1`), which is OpenAI/Anthropic-compatible. You can also
+> override the endpoint and model with `ORCAROUTER_BASE_URL` and `ORCAROUTER_MODEL`
+> (default `orcarouter/auto`). It also runs gateway-level, zero-trust security for AI
+> agents on the same endpoint — screening every prompt/response and governing every tool
+> call on a default-deny basis, with no application code changes.
+
 ## Setup Instructions
 
 ### Clone the repository:

--- a/src/agents/curate-data/nodes/tweets/group-tweets-by-content.ts
+++ b/src/agents/curate-data/nodes/tweets/group-tweets-by-content.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI } from "@langchain/openai";
+import { getChatModel } from "../../../../utils/llm.js";
 import { CurateDataState } from "../../state.js";
 import { GROUP_BY_CONTENT_CRITERIA } from "./prompts.js";
 
@@ -66,7 +66,7 @@ function parseGeneration(
 export async function groupTweetsByContent(
   state: CurateDataState,
 ): Promise<Partial<CurateDataState>> {
-  const model = new ChatOpenAI({ model: "o1", streaming: false });
+  const model = getChatModel({ model: "o1", streaming: false });
 
   const formattedUserPrompt = `Here are the tweets you should inspect, and group:
 <all-tweets>

--- a/src/agents/curate-data/nodes/tweets/re-group-tweets.ts
+++ b/src/agents/curate-data/nodes/tweets/re-group-tweets.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI } from "@langchain/openai";
+import { getChatModel } from "../../../../utils/llm.js";
 import { CurateDataState } from "../../state.js";
 import { GROUP_BY_CONTENT_CRITERIA } from "./prompts.js";
 import { TweetsGroupedByContent, TweetV2WithURLs } from "../../types.js";
@@ -135,7 +135,7 @@ export async function reGroupTweets(
     return {};
   }
 
-  const model = new ChatOpenAI({ model: "o1", streaming: false });
+  const model = getChatModel({ model: "o1", streaming: false });
 
   const { include, review } = splitGroups(
     state.tweetsGroupedByContent,

--- a/src/agents/curate-data/nodes/tweets/reflect-tweet-groups.ts
+++ b/src/agents/curate-data/nodes/tweets/reflect-tweet-groups.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI } from "@langchain/openai";
+import { getChatModel } from "../../../../utils/llm.js";
 import { CurateDataState } from "../../state.js";
 import { GROUP_BY_CONTENT_CRITERIA } from "./prompts.js";
 import { TweetV2WithURLs, TweetsGroupedByContent } from "../../types.js";
@@ -95,7 +95,7 @@ ${formatTweetsInGroup(group.tweets)}
 export async function reflectOnTweetGroups(
   state: CurateDataState,
 ): Promise<Partial<CurateDataState>> {
-  const model = new ChatOpenAI({ model: "o1", streaming: false });
+  const model = getChatModel({ model: "o1", streaming: false });
 
   const formattedUserPrompt = `Hi! Here are all of the groups I put together:
 ${formatUserPrompt(state.tweetsGroupedByContent)}

--- a/src/agents/curate-data/nodes/validate-bulk-tweets.ts
+++ b/src/agents/curate-data/nodes/validate-bulk-tweets.ts
@@ -1,4 +1,4 @@
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { CurateDataState } from "../state.js";
 import { z } from "zod";
 import { chunkArray } from "../../utils.js";
@@ -143,7 +143,7 @@ function formatTweets(tweets: TweetV2[]): string {
 export async function validateBulkTweets(
   state: CurateDataState,
 ): Promise<Partial<CurateDataState>> {
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   }).withStructuredOutput(answerSchema, { name: "answer" });

--- a/src/agents/generate-post/nodes/condense-post.ts
+++ b/src/agents/generate-post/nodes/condense-post.ts
@@ -1,4 +1,4 @@
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { GeneratePostAnnotation } from "../generate-post-state.js";
 import { parseGeneration } from "./generate-post/utils.js";
 import { filterLinksForPostContent, removeUrls } from "../../utils.js";
@@ -86,7 +86,7 @@ export async function condensePost(
     .replace("{originalPostLength}", originalPostLength)
     .replace("{reflectionsPrompt}", reflectionsPrompt);
 
-  const condensePostModel = new ChatAnthropic({
+  const condensePostModel = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0.5,
   });

--- a/src/agents/generate-post/nodes/generate-post/index.ts
+++ b/src/agents/generate-post/nodes/generate-post/index.ts
@@ -1,6 +1,6 @@
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { GeneratePostAnnotation } from "../../generate-post-state.js";
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../../utils/llm.js";
 import { GENERATE_POST_PROMPT } from "./prompts.js";
 import { formatPrompt, parseGeneration } from "./utils.js";
 import { ALLOWED_TIMES } from "../../constants.js";
@@ -20,7 +20,7 @@ export async function generatePost(
   if (!state.relevantLinks?.length) {
     throw new Error("No relevant links found");
   }
-  const postModel = new ChatAnthropic({
+  const postModel = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0.5,
   });

--- a/src/agents/generate-post/nodes/generate-report/index.ts
+++ b/src/agents/generate-post/nodes/generate-report/index.ts
@@ -1,6 +1,6 @@
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { GeneratePostAnnotation } from "../../generate-post-state.js";
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../../utils/llm.js";
 import { GENERATE_REPORT_PROMPT } from "./prompts.js";
 
 /**
@@ -36,7 +36,7 @@ export async function generateContentReport(
     );
   }
 
-  const reportModel = new ChatAnthropic({
+  const reportModel = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   });

--- a/src/agents/generate-post/nodes/rewrite-with-split-url.ts
+++ b/src/agents/generate-post/nodes/rewrite-with-split-url.ts
@@ -3,7 +3,7 @@ import {
   GeneratePostState,
   GeneratePostUpdate,
 } from "../generate-post-state.js";
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 
 const postSchema = z.object({
   main_post: z
@@ -37,7 +37,7 @@ Please split it into the two unique posts. Ensure the ONLY modification you make
 export async function rewritePostWithSplitUrl(
   state: GeneratePostState,
 ): Promise<GeneratePostUpdate> {
-  const postModel = new ChatAnthropic({
+  const postModel = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   }).bindTools(

--- a/src/agents/generate-report/nodes/extract-key-details.ts
+++ b/src/agents/generate-report/nodes/extract-key-details.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI } from "@langchain/openai";
+import { getChatModel } from "../../../utils/llm.js";
 import { GenerateReportState } from "../state.js";
 import { EXTRACT_KEY_DETAILS_PROMPT } from "../prompts.js";
 import { TweetsGroupedByContent } from "../../curate-data/types.js";
@@ -57,7 +57,7 @@ export async function extractKeyDetails(
     state.tweetGroup,
   );
 
-  const model = new ChatOpenAI({
+  const model = getChatModel({
     model: "o1",
     streaming: false,
   });

--- a/src/agents/generate-report/nodes/generate-report.ts
+++ b/src/agents/generate-report/nodes/generate-report.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI } from "@langchain/openai";
+import { getChatModel } from "../../../utils/llm.js";
 import { GenerateReportState } from "../state.js";
 import { GENERATE_REPORT_PROMPT_O1 } from "../prompts.js";
 import { TweetsGroupedByContent } from "../../curate-data/types.js";
@@ -78,7 +78,7 @@ export async function generateReport(
     tweetGroup: state.tweetGroup,
   });
 
-  const reportO1Model = new ChatOpenAI({
+  const reportO1Model = getChatModel({
     model: "o1",
     streaming: false,
   });

--- a/src/agents/generate-thread/nodes/generate-thread-plan.ts
+++ b/src/agents/generate-thread/nodes/generate-thread-plan.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI } from "@langchain/openai";
+import { getChatModel } from "../../../utils/llm.js";
 import { formatReportsForPrompt } from "../utils.js";
 import { GenerateThreadState } from "../state.js";
 
@@ -74,7 +74,7 @@ function parseTotalPosts(generation: string): number | undefined {
 export async function generateThreadPlan(
   state: GenerateThreadState,
 ): Promise<Partial<GenerateThreadState>> {
-  const model = new ChatOpenAI({
+  const model = getChatModel({
     model: "o1",
     streaming: false,
   });

--- a/src/agents/generate-thread/nodes/generate-thread-posts.ts
+++ b/src/agents/generate-thread/nodes/generate-thread-posts.ts
@@ -1,4 +1,4 @@
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import {
   formatAllPostsForPrompt,
   formatBodyPostsForPrompt,
@@ -145,7 +145,7 @@ Once you've completed these steps, provide your tweet inside <tweet> tags. Do no
 export async function generateThreadPosts(
   state: GenerateThreadState,
 ): Promise<Partial<GenerateThreadState>> {
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0, // TODO: Eval different temperatures
   });

--- a/src/agents/generate-thread/nodes/rewrite-thread.ts
+++ b/src/agents/generate-thread/nodes/rewrite-thread.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { GenerateThreadState } from "../state.js";
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import {
   getThreadReflections,
   THREAD_REFLECTIONS_PROMPT,
@@ -61,7 +61,7 @@ export async function rewriteThread(
     );
   }
 
-  const rewriteThreadModel = new ChatAnthropic({
+  const rewriteThreadModel = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   }).withStructuredOutput(schema, {

--- a/src/agents/ingest-repurposed-data/nodes/extract.ts
+++ b/src/agents/ingest-repurposed-data/nodes/extract.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { IngestRepurposedDataState, RepurposedContent } from "../types.js";
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { isValidUrl } from "../../utils.js";
 import { traceable } from "langsmith/traceable";
 import { DEFAULT_POST_QUANTITY } from "../constants.js";
@@ -55,7 +55,7 @@ const extractionSchema = z.object({
 async function extractContentsFunc(
   messageText: string,
 ): Promise<Omit<RepurposedContent, "attachmentUrls"> | undefined> {
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   }).bindTools(

--- a/src/agents/repurposer-post-interrupt/nodes/human-node/router.ts
+++ b/src/agents/repurposer-post-interrupt/nodes/human-node/router.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../../utils/llm.js";
 
 const ROUTE_POST_PROMPT = `You're an advanced AI assistant, tasked with routing a user's response.
 The only route which can be taken is 'rewrite_post'. If the user is not asking to rewrite a post, then choose the 'unknown_response' route.
@@ -25,7 +25,7 @@ export async function routeResponse(
   post: string,
   userResponse: string,
 ): Promise<z.infer<typeof routeResponseSchema>> {
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   }).bindTools(

--- a/src/agents/repurposer-post-interrupt/nodes/rewrite-posts.ts
+++ b/src/agents/repurposer-post-interrupt/nodes/rewrite-posts.ts
@@ -1,4 +1,4 @@
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { z } from "zod";
 import { formatReportForPrompt } from "../../repurposer/utils.js";
 import {
@@ -48,7 +48,7 @@ export async function rewritePost(
     throw new Error("Can not rewrite posts without user response");
   }
 
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   }).bindTools(

--- a/src/agents/repurposer/nodes/generate-campaign-plan.ts
+++ b/src/agents/repurposer/nodes/generate-campaign-plan.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI } from "@langchain/openai";
+import { getChatModel } from "../../../utils/llm.js";
 import { RepurposerState } from "../types.js";
 import { formatReportForPrompt } from "../utils.js";
 
@@ -72,7 +72,7 @@ some details text here
 export async function generateCampaignPlan(
   state: RepurposerState,
 ): Promise<Partial<RepurposerState>> {
-  const model = new ChatOpenAI({
+  const model = getChatModel({
     model: "o1",
     streaming: false,
   });

--- a/src/agents/repurposer/nodes/generate-posts.ts
+++ b/src/agents/repurposer/nodes/generate-posts.ts
@@ -1,4 +1,4 @@
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { getPrompts } from "../../generate-post/prompts/index.js";
 import { RepurposerState } from "../types.js";
 import { z } from "zod";
@@ -95,7 +95,7 @@ export async function generatePosts(
       ),
   });
 
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0.5,
   }).bindTools([

--- a/src/agents/shared/nodes/generate-post/rewrite-post.ts
+++ b/src/agents/shared/nodes/generate-post/rewrite-post.ts
@@ -1,7 +1,7 @@
 import { Client } from "@langchain/langgraph-sdk";
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { BaseGeneratePostState, BaseGeneratePostUpdate } from "./types.js";
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../../utils/llm.js";
 import {
   getReflectionsPrompt,
   REFLECTIONS_PROMPT,
@@ -60,7 +60,7 @@ export async function rewritePost<
     throw new Error("No user response found");
   }
 
-  const rewritePostModel = new ChatAnthropic({
+  const rewritePostModel = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0.5,
   });

--- a/src/agents/shared/nodes/route-response.ts
+++ b/src/agents/shared/nodes/route-response.ts
@@ -1,4 +1,4 @@
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { z } from "zod";
 
 const ROUTE_RESPONSE_PROMPT = `You are an AI assistant tasked with routing a user's response to one of two possible routes based on their intention. The two possible routes are:
@@ -90,7 +90,7 @@ export async function routeResponse({
   dateOrPriority,
   userResponse,
 }: RouteResponseArgs) {
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   });

--- a/src/agents/shared/nodes/update-scheduled-date.ts
+++ b/src/agents/shared/nodes/update-scheduled-date.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { toZonedTime } from "date-fns-tz";
 import { DateType } from "../../types.js";
 import { timezoneToUtc } from "../../../utils/date.js";
@@ -43,7 +43,7 @@ export async function updateScheduledDate(
   if (!state.userResponse) {
     throw new Error("No user response found");
   }
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0.5,
   }).withStructuredOutput(scheduleDateSchema, {

--- a/src/agents/shared/nodes/verify-content.ts
+++ b/src/agents/shared/nodes/verify-content.ts
@@ -1,4 +1,4 @@
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { traceable } from "langsmith/traceable";
 import { z } from "zod";
 
@@ -24,7 +24,7 @@ async function verifyContentIsRelevantFunc(
     schema: z.ZodType<z.infer<typeof RELEVANCY_SCHEMA>>;
   },
 ): Promise<boolean> {
-  const relevancyModel = new ChatAnthropic({
+  const relevancyModel = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
     // TODO: Type casting as any here shouldn't be required...

--- a/src/agents/supervisor/nodes/determine-post-type.ts
+++ b/src/agents/supervisor/nodes/determine-post-type.ts
@@ -1,4 +1,4 @@
-import { ChatAnthropic } from "@langchain/anthropic";
+import { getAnthropicModel } from "../../../utils/llm.js";
 import { SupervisorState } from "../supervisor-state.js";
 import { z } from "zod";
 
@@ -66,7 +66,7 @@ Please take your time, and identify the best type of post to generate for these 
 export async function determinePostType(
   state: SupervisorState,
 ): Promise<Partial<SupervisorState>> {
-  const model = new ChatAnthropic({
+  const model = getAnthropicModel({
     model: "claude-sonnet-4-5",
     temperature: 0,
   }).withStructuredOutput(postTypeSchema, {

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -1,0 +1,100 @@
+import { ChatOpenAI } from "@langchain/openai";
+import { ChatAnthropic } from "@langchain/anthropic";
+
+/**
+ * OrcaRouter gateway configuration.
+ *
+ * When `ORCAROUTER_API_KEY` is set, all chat models in this repo are routed
+ * through the [OrcaRouter](https://www.orcarouter.ai) gateway instead of the
+ * default provider endpoints. The gateway is OpenAI/Anthropic-compatible, so
+ * the existing `ChatOpenAI` / `ChatAnthropic` models can be pointed at it with
+ * a base URL override. It also runs gateway-level, zero-trust security for AI
+ * agents on the same endpoint — screening every prompt/response and governing
+ * every tool call on a default-deny basis, with no application code changes.
+ *
+ * Env vars:
+ * - `ORCAROUTER_API_KEY` (required to enable the gateway, `sk-orca-...`)
+ * - `ORCAROUTER_BASE_URL` (optional, defaults to `https://api.orcarouter.ai/v1`)
+ * - `ORCAROUTER_MODEL` (optional, defaults to `orcarouter/auto`)
+ */
+export const ORCAROUTER_BASE_URL =
+  process.env.ORCAROUTER_BASE_URL ?? "https://api.orcarouter.ai/v1";
+
+export const ORCAROUTER_DEFAULT_MODEL = "orcarouter/auto";
+
+/**
+ * Resolve the OrcaRouter gateway base URL. For OpenAI-compatible requests the
+ * OpenAI SDK appends `/chat/completions` directly to this value, so the default
+ * (`https://api.orcarouter.ai/v1`) is correct. The Anthropic SDK instead
+ * appends `/v1/messages`, so the trailing `/v1` is stripped for `ChatAnthropic`.
+ */
+function orcaBaseUrl(): string {
+  return process.env.ORCAROUTER_BASE_URL ?? "https://api.orcarouter.ai/v1";
+}
+
+function orcaAnthropicApiUrl(): string {
+  const base = orcaBaseUrl();
+  return base.replace(/\/v1$/, "");
+}
+
+export function isOrcarouterConfigured(): boolean {
+  return Boolean(process.env.ORCAROUTER_API_KEY);
+}
+
+export interface GetChatModelParams {
+  model: string;
+  temperature?: number;
+  streaming?: boolean;
+}
+
+/**
+ * Create an OpenAI chat model.
+ *
+ * If OrcaRouter is configured, the model is pointed at the OrcaRouter gateway
+ * (`ORCAROUTER_BASE_URL`) with the `sk-orca-...` key and, unless overridden,
+ * the `orcarouter/auto` adaptive model. Otherwise this is exactly the same as
+ * `new ChatOpenAI(params)`.
+ */
+export function getChatModel(params: GetChatModelParams): ChatOpenAI {
+  const orcaApiKey = process.env.ORCAROUTER_API_KEY;
+  if (orcaApiKey) {
+    return new ChatOpenAI({
+      model: process.env.ORCAROUTER_MODEL ?? ORCAROUTER_DEFAULT_MODEL,
+      temperature: params.temperature,
+      streaming: params.streaming ?? true,
+      apiKey: orcaApiKey,
+      configuration: {
+        baseURL: orcaBaseUrl(),
+      },
+    });
+  }
+  return new ChatOpenAI(params);
+}
+
+export interface GetAnthropicModelParams {
+  model: string;
+  temperature?: number;
+}
+
+/**
+ * Create an Anthropic chat model.
+ *
+ * If OrcaRouter is configured, the model is pointed at the OrcaRouter gateway
+ * (`ORCAROUTER_BASE_URL`) with the `sk-orca-...` key and, unless overridden,
+ * the `orcarouter/auto` adaptive model. Otherwise this is exactly the same as
+ * `new ChatAnthropic(params)`.
+ */
+export function getAnthropicModel(
+  params: GetAnthropicModelParams,
+): ChatAnthropic {
+  const orcaApiKey = process.env.ORCAROUTER_API_KEY;
+  if (orcaApiKey) {
+    return new ChatAnthropic({
+      model: process.env.ORCAROUTER_MODEL ?? ORCAROUTER_DEFAULT_MODEL,
+      temperature: params.temperature,
+      apiKey: orcaApiKey,
+      anthropicApiUrl: orcaAnthropicApiUrl(),
+    });
+  }
+  return new ChatAnthropic(params);
+}

--- a/src/utils/tests/llm.test.ts
+++ b/src/utils/tests/llm.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { ChatOpenAI } from "@langchain/openai";
+import { ChatAnthropic } from "@langchain/anthropic";
+import {
+  getChatModel,
+  getAnthropicModel,
+  isOrcarouterConfigured,
+  ORCAROUTER_BASE_URL,
+  ORCAROUTER_DEFAULT_MODEL,
+} from "../llm.js";
+
+const OLD_ENV = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...OLD_ENV };
+  delete process.env.ORCAROUTER_API_KEY;
+  delete process.env.ORCAROUTER_BASE_URL;
+  delete process.env.ORCAROUTER_MODEL;
+  process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+});
+
+describe("getChatModel", () => {
+  it("returns a default ChatOpenAI when OrcaRouter is not configured", () => {
+    const model = getChatModel({ model: "o1", streaming: false });
+    expect(model).toBeInstanceOf(ChatOpenAI);
+    expect(model.model).toBe("o1");
+  });
+
+  it("routes through OrcaRouter when ORCAROUTER_API_KEY is set", () => {
+    process.env.ORCAROUTER_API_KEY = "sk-orca-test";
+    const model = getChatModel({ model: "o1", streaming: false });
+    expect(model).toBeInstanceOf(ChatOpenAI);
+    expect(model.model).toBe(ORCAROUTER_DEFAULT_MODEL);
+    expect(model.apiKey).toBe("sk-orca-test");
+    expect(model.clientConfig.baseURL).toBe(ORCAROUTER_BASE_URL);
+  });
+
+  it("honors ORCAROUTER_BASE_URL and ORCAROUTER_MODEL overrides", () => {
+    process.env.ORCAROUTER_API_KEY = "sk-orca-test";
+    process.env.ORCAROUTER_BASE_URL = "https://gateway.example.com/v1";
+    process.env.ORCAROUTER_MODEL = "orcarouter/fusion";
+    const model = getChatModel({ model: "o1", streaming: false });
+    expect(model.model).toBe("orcarouter/fusion");
+    expect(model.clientConfig.baseURL).toBe("https://gateway.example.com/v1");
+  });
+});
+
+describe("getAnthropicModel", () => {
+  it("returns a default ChatAnthropic when OrcaRouter is not configured", () => {
+    const model = getAnthropicModel({
+      model: "claude-sonnet-4-5",
+      temperature: 0,
+    });
+    expect(model).toBeInstanceOf(ChatAnthropic);
+    expect(model.modelName).toBe("claude-sonnet-4-5");
+  });
+
+  it("routes through OrcaRouter when ORCAROUTER_API_KEY is set", () => {
+    process.env.ORCAROUTER_API_KEY = "sk-orca-test";
+    const model = getAnthropicModel({
+      model: "claude-sonnet-4-5",
+      temperature: 0,
+    });
+    expect(model).toBeInstanceOf(ChatAnthropic);
+    expect(model.modelName).toBe(ORCAROUTER_DEFAULT_MODEL);
+    expect(model.apiKey).toBe("sk-orca-test");
+    // The Anthropic SDK appends `/v1/messages`, so the trailing `/v1` is stripped.
+    expect(model.apiUrl).toBe("https://api.orcarouter.ai");
+  });
+});
+
+describe("isOrcarouterConfigured", () => {
+  it("returns false when no key is set", () => {
+    expect(isOrcarouterConfigured()).toBe(false);
+  });
+
+  it("returns true when ORCAROUTER_API_KEY is set", () => {
+    process.env.ORCAROUTER_API_KEY = "sk-orca-test";
+    expect(isOrcarouterConfigured()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds optional support for routing all chat model calls through the **[OrcaRouter](https://www.orcarouter.ai)** gateway.

The repo currently hardcodes `new ChatOpenAI(...)` and `new ChatAnthropic(...)` across 23 model call sites. This PR introduces a shared factory (`src/utils/llm.ts`) with `getChatModel()` / `getAnthropicModel()` and routes every call site through it. When `ORCAROUTER_API_KEY` is set, all models point at the OrcaRouter gateway (`https://api.orcarouter.ai/v1`, OpenAI/Anthropic-compatible) with the `orcarouter/auto` adaptive model; without the key, behavior is byte-for-byte unchanged.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

- `src/utils/llm.ts` (new): `getChatModel()` / `getAnthropicModel()` factory. Reads `ORCAROUTER_API_KEY`, `ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`), `ORCAROUTER_MODEL` (default `orcarouter/auto`) at call time. The Anthropic base URL strips the trailing `/v1` because the Anthropic SDK appends `/v1/messages`.
- 23 model call sites: replaced `new ChatOpenAI` / `new ChatAnthropic` with the factory (identical model/temperature params, `.bindTools` / `.withStructuredOutput` chains preserved).
- `.env.full.example`, `.env.quickstart.example`: documented `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` / `ORCAROUTER_MODEL`.
- `README.md`: documented the optional OrcaRouter gateway.
- `src/utils/tests/llm.test.ts` (new): 7 unit tests covering the default (no key) path, the OrcaRouter path, and env overrides for both `ChatOpenAI` and `ChatAnthropic`.

## Verification

- `yarn build` (tsc) — clean
- `yarn test` — 78 passed, 4 pre-existing skips
- `yarn lint` (eslint on all changed files) — 0 errors
- `yarn format:check` — clean
- `yarn lint:langgraph-json` — clean
- L3 live test: with a real `ORCAROUTER_API_KEY`, both `getChatModel(...).invoke(...)` (OpenAI-compatible `/chat/completions`) and `getAnthropicModel(...).invoke(...)` (Anthropic-compatible `/messages`) returned `ORCA-OK` from the OrcaRouter gateway.

Disclosure: I'm an engineer on the OrcaRouter team.
