### PR TITLE
fix: preserve LinkedIn organization config in interrupt runs (#352)

### DIFF
--- a/src/agents/repurposer/nodes/start-interrupt-graph.ts
+++ b/src/agents/repurposer/nodes/start-interrupt-graph.ts
@@ -1,9 +1,14 @@
+import { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { Client } from "@langchain/langgraph-sdk";
+import { POST_TO_LINKEDIN_ORGANIZATION } from "../../generate-post/constants.js";
+import { shouldPostToLinkedInOrg } from "../../utils.js";
 import { RepurposerState, RepurposerUpdate } from "../types.js";
 
 export async function startInterruptGraphRuns(
   state: RepurposerState,
+  config?: LangGraphRunnableConfig,
 ): Promise<RepurposerUpdate> {
+  const postToLinkedInOrg = shouldPostToLinkedInOrg(config);
   const client = new Client({
     apiUrl: process.env.LANGGRAPH_API_URL,
     apiKey: process.env.LANGCHAIN_API_KEY,
@@ -25,6 +30,11 @@ export async function startInterruptGraphRuns(
           imageOptions: state.imageOptions,
           posts: state.posts,
           campaignPlan: state.campaignPlan,
+        },
+        config: {
+          configurable: {
+            [POST_TO_LINKEDIN_ORGANIZATION]: postToLinkedInOrg,
+          },
         },
       });
     }),

--- a/src/agents/repurposer/tests/start-interrupt-graph.test.ts
+++ b/src/agents/repurposer/tests/start-interrupt-graph.test.ts
@@ -1,0 +1,126 @@
+import http from "node:http";
+import { expect, test } from "@jest/globals";
+import { POST_TO_LINKEDIN_ORGANIZATION } from "../../generate-post/constants.js";
+import { startInterruptGraphRuns } from "../nodes/start-interrupt-graph.js";
+import { RepurposerState } from "../types.js";
+
+async function readChildRunConfig(
+  environmentValue: "true" | "false",
+  parentValue?: boolean,
+): Promise<unknown> {
+  const requests: Array<{ method?: string; url?: string; body: string }> = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      requests.push({ method: req.method, url: req.url, body });
+      res.setHeader("content-type", "application/json");
+
+      if (req.method === "POST" && req.url === "/threads") {
+        res.end(JSON.stringify({ thread_id: "thread-1" }));
+        return;
+      }
+
+      if (req.method === "POST" && req.url?.includes("/runs")) {
+        res.end(JSON.stringify({ run_id: "run-1" }));
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: "not found" }));
+    });
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve()),
+  );
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error("Failed to start test server");
+  }
+
+  const previousApiUrl = process.env.LANGGRAPH_API_URL;
+  const previousPostToOrg = process.env.POST_TO_LINKEDIN_ORGANIZATION;
+
+  try {
+    process.env.LANGGRAPH_API_URL = `http://127.0.0.1:${address.port}`;
+    process.env.POST_TO_LINKEDIN_ORGANIZATION = environmentValue;
+
+    const state = {
+      posts: [{ content: "p1", index: 0 }],
+      images: [],
+      originalLink: "https://example.com",
+      originalContent: "orig",
+      contextLinks: ["https://ctx.example.com"],
+      additionalContexts: [],
+      pageContents: [],
+      quantity: 1,
+      reports: [{ report: "report", keyDetails: "details" }],
+      imageOptions: ["image option"],
+      campaignPlan: "plan",
+      userResponse: undefined,
+      next: "unknownResponse",
+      scheduleDate: undefined,
+      numWeeksBetween: 1,
+    } as RepurposerState;
+
+    const config =
+      parentValue === undefined
+        ? undefined
+        : {
+            configurable: {
+              [POST_TO_LINKEDIN_ORGANIZATION]: parentValue,
+            },
+          };
+
+    await startInterruptGraphRuns(state, config);
+  } finally {
+    if (previousApiUrl === undefined) {
+      delete process.env.LANGGRAPH_API_URL;
+    } else {
+      process.env.LANGGRAPH_API_URL = previousApiUrl;
+    }
+
+    if (previousPostToOrg === undefined) {
+      delete process.env.POST_TO_LINKEDIN_ORGANIZATION;
+    } else {
+      process.env.POST_TO_LINKEDIN_ORGANIZATION = previousPostToOrg;
+    }
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  const runRequest = requests.find((request) => request.url?.includes("/runs"));
+  expect(runRequest).toBeDefined();
+
+  const payload = JSON.parse(runRequest?.body ?? "{}");
+  return payload.config;
+}
+
+test("parent false overrides an environment default of true", async () => {
+  await expect(readChildRunConfig("true", false)).resolves.toEqual({
+    configurable: {
+      [POST_TO_LINKEDIN_ORGANIZATION]: false,
+    },
+  });
+});
+
+test("parent true overrides an environment default of false", async () => {
+  await expect(readChildRunConfig("false", true)).resolves.toEqual({
+    configurable: {
+      [POST_TO_LINKEDIN_ORGANIZATION]: true,
+    },
+  });
+});
+
+test("uses the environment default when the parent config is absent", async () => {
+  await expect(readChildRunConfig("false")).resolves.toEqual({
+    configurable: {
+      [POST_TO_LINKEDIN_ORGANIZATION]: false,
+    },
+  });
+});


### PR DESCRIPTION
## Description

Fixes #352.

The repurposer workflow creates a new `repurposer_post_interrupt` run using the LangGraph SDK. Previously, configurable values from the parent run were not forwarded to the child run, causing the child run to fall back to environment variables.

This change explicitly propagates `POST_TO_LINKEDIN_ORGANIZATION` to the child run config.

## Changes

- Pass `LangGraphRunnableConfig` into `startInterruptGraphRuns`
- Forward `POST_TO_LINKEDIN_ORGANIZATION` when creating interrupt runs
- Add regression tests covering:
  - parent config overriding environment defaults
  - both true and false values
  - environment fallback when parent config is absent

## Tests

Passed:
- `yarn test:single src/agents/repurposer/tests/start-interrupt-graph.test.ts`
- `yarn build`
- `yarn lint`

Note:
- Full `yarn test` currently reports an unrelated failure in `src/tests/langgraph-config.test.ts` caused by LF/CRLF handling in `yarn.lock`.
- Full prettier check reports existing repository-wide formatting issues unrelated to this change.