### PR TITLE
fix(deps): bump qs to 6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "axios": "^1.18.1",
     "jws": "^4.0.1",
     "form-data": "^4.0.4",
-    "qs": "^6.14.1",
+    "qs": "^6.16.0",
     "lodash": "^4.18.1",
     "brace-expansion": "^2.1.2",
     "**/@istanbuljs/load-nyc-config/js-yaml": "^3.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,12 +5921,13 @@ pure-rand@^7.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-7.0.1.tgz#6f53a5a9e3e4a47445822af96821ca509ed37566"
   integrity sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==
 
-qs@^6.14.0, qs@^6.14.1, qs@^6.15.2, qs@^6.7.0, qs@~6.5.2:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
-  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
+qs@^6.14.0, qs@^6.15.2, qs@^6.16.0, qs@^6.7.0, qs@~6.5.2:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
-    side-channel "^1.1.0"
+    es-define-property "^1.0.1"
+    side-channel "^1.1.1"
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -6302,6 +6303,14 @@ side-channel-list@^1.0.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
 
+side-channel-list@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
+  integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+
 side-channel-map@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
@@ -6341,6 +6350,17 @@ side-channel@^1.1.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
     side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
+side-channel@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 


### PR DESCRIPTION
## Summary
- bump the existing `qs` resolution from `^6.14.1` to `^6.16.0`
- regenerate `yarn.lock` with the repository-pinned Yarn 1.22.22
- resolves Dependabot alert #246 / GHSA-x5fp-wj9c-mxmx

## Validation
- [x] `yarn install --frozen-lockfile`
- [x] `yarn check --integrity`
- [x] `yarn build`
- [x] `yarn lint` (passes with 8 pre-existing warnings)
- [ ] `yarn test --runInBand` (blocked by the Fleet sandbox 1 GB Node heap limit; Jest exits with OOM)

Scoped to the affected resolution and lockfile entries.